### PR TITLE
Fix title in decrypt prompt

### DIFF
--- a/screens/NoteViewScreen.js
+++ b/screens/NoteViewScreen.js
@@ -93,7 +93,7 @@ export default function NoteViewScreen({ route, navigation }) {
             {showDecryptPrompt && (
                 <PasswordPrompt
                     visible
-                    title={t()}
+                    title={t('disable_encryption')}
                     onSubmit={onDecryptDisable}
                     onDismiss={() => setShowDecryptPrompt(false)}
                 />


### PR DESCRIPTION
## Summary
- show the correct title when disabling note encryption

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684574ab145c8333b8020684a7af09b3