### PR TITLE
Fix duplicate style key in NotesScreenStyles

### DIFF
--- a/styles/NotesScreenStyles.js
+++ b/styles/NotesScreenStyles.js
@@ -25,7 +25,6 @@ export const NotesScreenStyles = StyleSheet.create({
         bottom: 16,
         backgroundColor: theme.colors.primary
     },
-    container: { flex: 1, padding: 16, backgroundColor: 'white' },
     title: { fontSize: 24, fontWeight: 'bold', marginBottom: 12 },
     editBtn: { marginTop: 16 },
 });


### PR DESCRIPTION
## Summary
- remove second `container` definition from `NotesScreenStyles`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684574a898748333be75fb147af2fea5