### PR TITLE
Add authentication screen on launch

### DIFF
--- a/App.js
+++ b/App.js
@@ -10,6 +10,7 @@ import RemovePinScreen from './screens/RemovePinScreen';
 import NotesScreen from './screens/NotesScreen';
 import NoteViewScreen from './screens/NoteViewScreen';
 import NoteEditorScreen from './screens/NoteEditorScreen';
+import LaunchAuthScreen from './screens/LaunchAuthScreen';
 import { AppProvider } from './contexts/AppContext';
 import AppContext from './contexts/AppContext';
 import './i18n';
@@ -34,12 +35,14 @@ export default function App() {
 }
 
 function MainNavigator() {
-  const { isAuthenticated, isLoading, authenticate } = React.useContext(AppContext);
+  const { isAuthenticated, isLoading, authenticate, settings } = React.useContext(AppContext);
   const { t } = useTranslation();
 
   React.useEffect(() => {
-    authenticate();
-  }, []);
+    if (!isLoading) {
+      authenticate();
+    }
+  }, [isLoading]);
 
   React.useEffect(() => {
     if (!isLoading) {
@@ -52,6 +55,9 @@ function MainNavigator() {
   }
 
   if (!isAuthenticated) {
+    if (settings.requestAuthOnLaunch && (settings.hasPin || settings.biometricEnabled)) {
+      return <LaunchAuthScreen />;
+    }
     return null;
   }
 

--- a/contexts/AppContext.js
+++ b/contexts/AppContext.js
@@ -1,6 +1,5 @@
 import React, { createContext, useState, useEffect } from 'react';
 import AsyncStorage from '@react-native-async-storage/async-storage';
-import * as LocalAuthentication from 'expo-local-authentication';
 import i18n from '../i18n';
 
 const AppContext = createContext();
@@ -39,21 +38,7 @@ export function AppProvider({ children }) {
 
     const authenticate = async () => {
         if (settings.requestAuthOnLaunch && (settings.hasPin || settings.biometricEnabled)) {
-            const isAvailable = await LocalAuthentication.hasHardwareAsync();
-            const isEnrolled = await LocalAuthentication.isEnrolledAsync();
-
-            if (settings.biometricEnabled && isAvailable && isEnrolled) {
-                const result = await LocalAuthentication.authenticateAsync({
-                    promptMessage: settings.language === 'ru'
-                        ? 'Введите PIN устройства или используйте биометрию'
-                        : 'Enter device PIN or use biometrics',
-                });
-                setIsAuthenticated(result.success);
-            } else if (settings.hasPin) {
-                setIsAuthenticated(false);
-            } else {
-                setIsAuthenticated(true);
-            }
+            setIsAuthenticated(false);
         } else {
             setIsAuthenticated(true);
         }

--- a/screens/LaunchAuthScreen.js
+++ b/screens/LaunchAuthScreen.js
@@ -1,0 +1,89 @@
+import React, { useContext, useEffect, useState } from 'react';
+import { View, Text, TextInput, Alert } from 'react-native';
+import { ActivityIndicator, Button } from 'react-native-paper';
+import MaterialCommunityIcons from 'react-native-vector-icons/MaterialCommunityIcons';
+import * as LocalAuthentication from 'expo-local-authentication';
+import AppContext from '../contexts/AppContext';
+import { useTranslation } from 'react-i18next';
+
+export default function LaunchAuthScreen() {
+    const { settings, verifyPin } = useContext(AppContext);
+    const { t } = useTranslation();
+    const [checking, setChecking] = useState(true);
+    const [pinInput, setPinInput] = useState('');
+
+    useEffect(() => {
+        attemptBiometric();
+    }, []);
+
+    const attemptBiometric = async () => {
+        if (settings.biometricEnabled) {
+            const isAvailable = await LocalAuthentication.hasHardwareAsync();
+            const isEnrolled = await LocalAuthentication.isEnrolledAsync();
+            if (isAvailable && isEnrolled) {
+                const result = await LocalAuthentication.authenticateAsync({
+                    promptMessage: t('auth_prompt'),
+                });
+                if (result.success) {
+                    await verifyPin(settings.pinCode);
+                    return;
+                }
+            }
+        }
+        setChecking(false);
+    };
+
+    const handlePinSubmit = async () => {
+        const success = await verifyPin(pinInput);
+        if (!success) {
+            Alert.alert(t('wrong_pin'), t('try_again'));
+            setPinInput('');
+        }
+    };
+
+    if (checking) {
+        return (
+            <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
+                <ActivityIndicator size="large" />
+            </View>
+        );
+    }
+
+    return (
+        <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
+            <MaterialCommunityIcons name="lock" size={80} color="gray" style={{ marginBottom: 24, marginTop: 70 }} />
+            <Text style={{ fontSize: 18, marginBottom: 24 }}>{t('locked_tab')}</Text>
+
+            {!settings.biometricEnabled && (
+                <>
+                    <TextInput
+                        value={pinInput}
+                        onChangeText={setPinInput}
+                        placeholder={t('enter_pin')}
+                        secureTextEntry
+                        keyboardType="numeric"
+                        style={{
+                            width: 200,
+                            height: 50,
+                            borderColor: 'gray',
+                            borderWidth: 1,
+                            borderRadius: 10,
+                            paddingHorizontal: 16,
+                            marginBottom: 24,
+                            backgroundColor: '#fff',
+                        }}
+                    />
+                    <Button mode="contained" onPress={handlePinSubmit}>
+                        {t('unlock')}
+                    </Button>
+                </>
+            )}
+
+            {settings.biometricEnabled && (
+                <Button mode="contained" onPress={attemptBiometric}>
+                    {t('unlock')}
+                </Button>
+            )}
+        </View>
+    );
+}


### PR DESCRIPTION
## Summary
- add a `LaunchAuthScreen` component for PIN/biometric prompts
- update `App.js` to show the new screen when authentication is required
- simplify `authenticate` logic in context and remove unused import

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6845789fb84483338acf4dc5a8daadc5